### PR TITLE
FIX: Handle null x_scores in _PLS NIPALS loop

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -325,7 +325,20 @@ class _PLS(
             y_scores = np.dot(yk, y_weights) / y_ss
 
             # Deflation: subtract rank-one approx to obtain Xk+1 and yk+1
-            x_loadings = np.dot(x_scores, Xk) / np.dot(x_scores, x_scores)
+            x_scores_ss = np.dot(x_scores, x_scores)
+
+            # Safety check to prevent division by zero when x_scores are all zero.
+            # This indicates that the current component is uninformative.
+            if x_scores_ss < np.finfo(np.float64).eps:
+                # The algorithm can proceed with the components found so far.
+                warnings.warn(
+                    f"x_scores are null at iteration {k}. The algorithm may have stopped"
+                    " before reaching the desired number of components.",
+                    ConvergenceWarning,
+                )
+                break
+
+            x_loadings = np.dot(x_scores, Xk) / x_scores_ss
             Xk -= np.outer(x_scores, x_loadings)
 
             if self.deflation_mode == "canonical":


### PR DESCRIPTION
Prevents a `ValueError` in PLSRegression when a predictor has zero variance.

The deflation step was susceptible to a division-by-zero error if the `x_scores` vector became null, leading to a crash in the final SVD call.

This adds a check before the division. If `x_scores` is null, the component-building loop is terminated gracefully, and a `ConvergenceWarning` is issued.